### PR TITLE
log-backup: update flush time if succeeding in do_flush

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -47,7 +47,7 @@ use crate::{
     metadata::{store::MetaStore, MetadataClient, MetadataEvent, StreamTask},
     metrics::{self, TaskStatus},
     observer::BackupStreamObserver,
-    router::{ApplyEvents, Router, FLUSH_STORAGE_INTERVAL},
+    router::{ApplyEvents, Router},
     subscription_manager::RegionSubscriptionManager,
     subscription_track::SubscriptionTracer,
     try_send,
@@ -215,9 +215,9 @@ where
 
     async fn starts_flush_ticks(router: Router) {
         loop {
-            // check every 15s.
+            // check every 5s.
             // TODO: maybe use global timer handle in the `tikv_utils::timer` (instead of enabling timing in the current runtime)?
-            tokio::time::sleep(Duration::from_secs(FLUSH_STORAGE_INTERVAL / 20)).await;
+            tokio::time::sleep(Duration::from_secs(5)).await;
             debug!("backup stream trigger flush tick");
             router.tick().await;
         }


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/tikv/issues/12802

What's Changed:
- Run tick() every 5 second, it can `flush` and advancing of `checkpoint-ts` in time.
- Update flush timestamp if succeeding in do_flush, or retry to flush.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Manual test
- create a task. `br log start`
- make a breakdown for `minio` storage.
- the log-backup task failed to do_flush and retry for 60 time for 10 minutes. The status of task became error finally.
- The gc safe point keep at checkpoint-ts of task for 24 h.
![image](https://user-images.githubusercontent.com/57036248/173268168-db45ee7f-0ac6-4d3b-9dae-a5a4a97e3a24.png)

`
[2022/06/11 19:39:03.838 +08:00] [WARN] [errors.rs:135] ["backup stream meet error"] [err="I/O Error: failed to put object rusoto error Error during dispatch: error trying to connect: tcp connect error: Connection refused (os error     111)"] [context="failed to flush task."]
 [2022/06/11 19:43:12.820 +08:00] [WARN] [errors.rs:135] ["backup stream meet error"] [err="I/O Error: failed to put object rusoto error Error during dispatch: error trying to connect: tcp connect error: Connection refused (os error     111)"] [context="failed to flush task."]
`


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
