### PR TITLE
br: remove metrics after task stopped

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -602,12 +602,14 @@ where
 
     pub fn on_unregister(&self, task: &str) -> Option<StreamBackupTaskInfo> {
         let info = self.unload_task(task);
-
-        // reset the checkpoint ts of the task so it won't mislead the metrics.
-        metrics::STORE_CHECKPOINT_TS
-            .with_label_values(&[task])
-            .set(0);
+        self.remove_metrics_after_unregister(task);
         info
+    }
+
+    fn remove_metrics_after_unregister(&self, task: &str) {
+        // remove metrics of the task so it won't mislead the metrics.
+        metrics::STORE_CHECKPOINT_TS.remove_label_values(&[task]);
+        metrics::remove_task_status_metric(task);
     }
 
     /// unload a task from memory: this would stop observe the changes required by the task temporarily.

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -3,7 +3,6 @@
 use std::{
     fmt,
     marker::PhantomData,
-    panic::resume_unwind,
     path::PathBuf,
     sync::{atomic::Ordering, Arc},
     time::Duration,
@@ -609,12 +608,12 @@ where
 
     fn remove_metrics_after_unregister(&self, task: &str) {
         // remove metrics of the task so it won't mislead the metrics.
-        metrics::STORE_CHECKPOINT_TS
+        let _ = metrics::STORE_CHECKPOINT_TS
             .remove_label_values(&[task])
             .map_err(
                 |err| info!("failed to remove checkpoint ts metric"; "task" => task, "err" => %err),
             );
-        metrics::remove_task_status_metric(task).map_err(
+        let _ = metrics::remove_task_status_metric(task).map_err(
             |err| info!("failed to remove checkpoint ts metric"; "task" => task, "err" => %err),
         );
     }

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -3,6 +3,7 @@
 use std::{
     fmt,
     marker::PhantomData,
+    panic::resume_unwind,
     path::PathBuf,
     sync::{atomic::Ordering, Arc},
     time::Duration,
@@ -608,8 +609,14 @@ where
 
     fn remove_metrics_after_unregister(&self, task: &str) {
         // remove metrics of the task so it won't mislead the metrics.
-        metrics::STORE_CHECKPOINT_TS.remove_label_values(&[task]);
-        metrics::remove_task_status_metric(task);
+        metrics::STORE_CHECKPOINT_TS
+            .remove_label_values(&[task])
+            .map_err(
+                |err| info!("failed to remove checkpoint ts metric"; "task" => task, "err" => %err),
+            );
+        metrics::remove_task_status_metric(task).map_err(
+            |err| info!("failed to remove checkpoint ts metric"; "task" => task, "err" => %err),
+        );
     }
 
     /// unload a task from memory: this would stop observe the changes required by the task temporarily.

--- a/components/backup-stream/src/metrics.rs
+++ b/components/backup-stream/src/metrics.rs
@@ -25,8 +25,8 @@ pub fn update_task_status(status: TaskStatus, task: &str) {
     }
 }
 
-pub fn remove_task_status_metric(task: &str) {
-    TASK_STATUS.remove_label_values(&[task]);
+pub fn remove_task_status_metric(task: &str) -> Result<()> {
+    TASK_STATUS.remove_label_values(&[task])
 }
 
 lazy_static! {

--- a/components/backup-stream/src/metrics.rs
+++ b/components/backup-stream/src/metrics.rs
@@ -25,6 +25,10 @@ pub fn update_task_status(status: TaskStatus, task: &str) {
     }
 }
 
+pub fn remove_task_status_metric(task: &str) {
+    TASK_STATUS.remove_label_values(&[task]);
+}
+
 lazy_static! {
     pub static ref INTERNAL_ACTOR_MESSAGE_HANDLE_DURATION: HistogramVec = register_histogram_vec!(
         "tikv_log_backup_interal_actor_acting_duration_sec",


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->

close https://github.com/tikv/tikv/issues/12786


What's Changed:

remove checkpoint ts metric and task status metric after task stopped


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

1. start log backup
2. there are metrics appearing in grafana
3. stop log backup
4. metrics disappeared after stop operation

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
