### PR TITLE
log_backup: update max ts

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -653,6 +653,7 @@ where
                 .await
                 .map_err(|err| Error::from(err).report("failed to get tso from pd"))
                 .unwrap_or_default();
+            cm.update_max_ts(pd_tso);
             let min_ts = cm.global_min_lock_ts().unwrap_or(TimeStamp::max());
             Ord::min(pd_tso, min_ts)
         }


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

### What is changed and how it works?

What's Changed:

Update `max_ts` before advancing resolved ts.

<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix a bug that may make async commit using `commit_ts` less than resolved ts to commit.
```
