### PR TITLE
log-backup: store log files by date and keep advanced checkpoint-ts as safe point with ttl 12 hours

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -55,7 +55,7 @@ use crate::{
 };
 
 const SLOW_EVENT_THRESHOLD: f64 = 120.0;
-/// CHECKPOINT_TS_SAFE_POINT_TTL specifies the safe point TTL(12 hour) for checkpoint-ts.
+/// CHECKPOINT_SAFEPOINT_TTL_IF_NOT_ADVANCE specifies the safe point TTL(12 hour) for checkpoint-ts.
 /// If the checkpoint-ts advances, the safe-point of old checkpoint-ts will be overwrite by new one.
 const CHECKPOINT_SAFEPOINT_TTL_IF_NOT_ADVANCE: u64 = 12;
 /// CHECKPOINT_SAFEPOINT_TTL_IF_ERROR specifies the safe point TTL(24 hour) if task has fatal error.

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -606,20 +606,24 @@ impl TempFileKey {
         return dt.format("%Y%m%d");
     }
 
+    /// path_to_log_file specifies the path of record log.
+    /// eg. "v1/20220625/t00000071/434098800931373064-f0251bd5-1441-499a-8f53-adc0d1057a73.log"
     fn path_to_log_file(&self, min_ts: u64, max_ts: u64) -> String {
         format!(
-            "v1/t{:08}/{}-{:012}-{}.log",
-            self.table_id,
+            "v1/{}/t{:08}/{:012}-{}.log",
             // We may delete a range of files, so using the max_ts for preventing remove some records wrong.
             Self::format_date_time(max_ts),
+            self.table_id,
             min_ts,
             uuid::Uuid::new_v4()
         )
     }
 
+    /// path_to_schema_file specifies the path of schema log.
+    /// eg. "v1/20220625/schema-meta/434055683656384515-cc3cb7a3-e03b-4434-ab6c-907656fddf67.log"
     fn path_to_schema_file(min_ts: u64, max_ts: u64) -> String {
         format!(
-            "v1/schema-meta/{}-{:012}-{}.log",
+            "v1/{}/schema-meta/{:012}-{}.log",
             Self::format_date_time(max_ts),
             min_ts,
             uuid::Uuid::new_v4(),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: https://github.com/tikv/tikv/issues/12903

What's Changed:
- store log files by date.
- keep advanced checkpoint-ts as safe point with ttl 12 hours.

the directory tree like:
![image](https://user-images.githubusercontent.com/57036248/175496173-fe49f319-a728-45c1-a2dd-9f9bcd2aa953.png)



<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```commit-message
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

### Manual test
- run workload with tpcc test
- create log backup task in up-stream
- `br backup full` in up-stream
- `br restore point ` in down-stream
- sync-diff between up-stream and down-stream

### test output
- the directory 
![image](https://user-images.githubusercontent.com/57036248/175510963-94282853-0b3c-4e8e-b6ed-bcb50394b828.png)
- run `br restore point` successfully.
- run sync-diff successfully between up-stream and down-stream

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
